### PR TITLE
Propagate PHP_MIN_VERSION definition from the archive npgCore/setup/i…

### DIFF
--- a/createziparchive/createziparchive.php
+++ b/createziparchive/createziparchive.php
@@ -27,7 +27,7 @@
 
 /*
  * 	Adapted for netPhotoGraphics by Stephen Billard
- * 	Copyright 2014 by Stephen L Billard for use in {@link https://github.com/ZenPhoto20/netPhotoGraphics ZenPhoto20}
+ * 	Copyright 2020 by Stephen L Billard for use in {@link https://github.com/ZenPhoto20/netPhotoGraphics ZenPhoto20}
  * 	This copyright notice MUST APPEAR in all copies of the script!
  */
 @ini_set('memory_limit', '-1');
@@ -58,12 +58,7 @@ try {
 			break;
 	}
 
-	if (file_exists($sourcefolder . 'zp-core/version.php')) {
-		$core = 'zp-core';
-	} else {
-		$core = 'npgCore';
-	}
-	require_once($sourcefolder . $core . '/version.php');
+	require_once($sourcefolder . 'npgCore/version.php');
 	if (defined('NETPHOTOGRAPHICS_VERSION')) {
 		$version = NETPHOTOGRAPHICS_VERSION;
 	} else {
@@ -71,6 +66,10 @@ try {
 	}
 	$version = explode('-', $version);
 	define('VERSION', $version[0]);
+	$setup_index = file_get_contents($sourcefolder . 'npgCore/setup/index.php');
+	preg_match('~define\([\"\']PHP_MIN_VERSION[\"\']\,\s*[\"\'](.*)[\"\']\);~i', $setup_index, $matches);
+	$php_min_version = $matches[0];
+
 	$targetname = TARGET . 'extract.php.bin';
 	$zipfilename = md5(time()) . 'extract.zip'; // replace with tempname()
 	if (file_exists(TARGET . 'setup-' . VARIENT . '-' . VERSION . '.zip'))
@@ -79,7 +78,7 @@ try {
 	// create a archive from the submitted folder
 	$zipfile = new ZipArchive();
 	$zipfile->open($zipfilename, ZipArchive::CREATE);
-	addFiles2Zip($zipfile, $sourcefolder . $core . '/', $sourcefolder);
+	addFiles2Zip($zipfile, $sourcefolder . 'npgCore/', $sourcefolder);
 	addFiles2Zip($zipfile, $sourcefolder . 'themes/', $sourcefolder);
 	addFiles2Zip($zipfile, $sourcefolder . 'plugins/', $sourcefolder);
 	$zipfile->addFile($sourcefolder . '/docs/release notes.htm', 'docs/release notes.htm');
@@ -96,8 +95,8 @@ try {
 
 	$i = 0;
 	while ($buffer = fgets($fp_cur)) {
+		$buffer = str_replace("Define('PHP_MIN_VERSION', 'd.d');", $php_min_version, $buffer);
 		$buffer = str_replace('_VERSION_', VERSION, $buffer);
-		$buffer = str_replace('_CORE_', $core, $buffer);
 		fwrite($fp_dest, $buffer);
 	}
 	fclose($fp_cur);

--- a/createziparchive/extractor.php
+++ b/createziparchive/extractor.php
@@ -2,10 +2,10 @@
 /*
  * 	This script is a derivitive of work produced by createziparchive (c) 2008 iljitsch@mail.com cookiepattern.blogspot.com
  *
- * 	The derivitive work is copyright (c) 2014 by Stephen Billard, all rights reserved
+ * 	The derivitive work is copyright (c) 2020 by Stephen Billard, all rights reserved
  * 	This copyright notice must be included in all copies of this script.
  */
-Define('PHP_MIN_VERSION', '5.2');
+Define('PHP_MIN_VERSION', 'd.d');
 if (version_compare(PHP_VERSION, PHP_MIN_VERSION, '<')) {
 	die(sprintf(gettext('netPhotoGraphics requires PHP version %s or greater'), PHP_MIN_VERSION));
 }
@@ -79,12 +79,12 @@ try {
 	?>
 	done...
 	<br />
-	<a href="<?php echo $const_webpath . '/_CORE_/setup/index.php?autorun=admin'; ?>">run setup</a>
+	<a href="<?php echo $const_webpath . '/npgCore/setup/index.php?autorun=admin'; ?>">run setup</a>
 
 	<script>
 		// <!-- <![CDATA[
 		window.onload = function () {
-			window.location = '<?php echo $const_webpath; ?>/_CORE_/setup/index.php?autorun=admin';
+			window.location = '<?php echo $const_webpath; ?>/npgCore/setup/index.php?autorun=admin';
 		}
 		// ]]> -->
 	</script>


### PR DESCRIPTION
…ndex.php script so that the install extractor will always be in sync with the currently set minimum level.